### PR TITLE
Feature/better extend formula

### DIFF
--- a/contracts/JBveBanny.sol
+++ b/contracts/JBveBanny.sol
@@ -301,9 +301,7 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
     if (!_isLockDurationAcceptable(_updatedDuration)) revert JBErrors.INVALID_LOCK_DURATION();
 
     // Get the specs for the token ID.
-    (uint256 _count, uint256 _duration, uint256 _lockedUntil, bool _useJbToken) = getSpecs(
-      _tokenId
-    );
+    (uint256 _count, , uint256 _lockedUntil, bool _useJbToken) = getSpecs(_tokenId);
 
     // No time remaining if the lock has expired.
     uint256 _timeRemaining = (block.timestamp >= _lockedUntil) ? 0 : _lockedUntil - block.timestamp;

--- a/contracts/JBveBanny.sol
+++ b/contracts/JBveBanny.sol
@@ -301,9 +301,9 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
     @param _lockExtensionData An array of locks to extend.
   */
   function extendLock(JBLockExtensionData[] calldata _lockExtensionData) external nonReentrant {
-    for (uint256 _i; _i < _lockExtensionData; _i++) {
+    for (uint256 _i; _i < _lockExtensionData.length; _i++) {
       // Get a reference to the extension being iterated.
-      JBLockExtensionData _data = _lockExtensionData[_i];
+      JBLockExtensionData memory _data = _lockExtensionData[_i];
 
       // Duration must match.
       if (!_isLockDurationAcceptable(_data.updatedDuration))
@@ -312,14 +312,14 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
       // Get the specs for the token ID.
       (
         uint256 _count,
-        ,
+        uint256 _duration,
         uint256 _lockedUntil,
         bool _useJbToken,
         bool _allowPublicExtension
       ) = getSpecs(_data.tokenId);
 
-      // If the operation isn't allowed publicly, check if the msg.sender is either the position owner or is an operator.
       if (!_allowPublicExtension)
+        // If the operation isn't allowed publicly, check if the msg.sender is either the position owner or is an operator.
         _requirePermission(ownerOf(_data.tokenId), projectId, JBStakingOperations.EXTEND_LOCK);
 
       // No time remaining if the lock has expired.
@@ -359,12 +359,13 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
 
     @param _allowPublicExtensionData An array of locks to extend.
   */
-  function setAllowPublicExtensionFlag(
-    JBAllowPublicExtensionData[] calldata _allowPublicExtensionData
-  ) external nonReentrant {
-    for (uint256 _i; _i < _allowPublicExtensionData; _i++) {
+  function setAllowPublicExtension(JBAllowPublicExtensionData[] calldata _allowPublicExtensionData)
+    external
+    nonReentrant
+  {
+    for (uint256 _i; _i < _allowPublicExtensionData.length; _i++) {
       // Get a reference to the extension being iterated.
-      JBAllowPublicExtensionData _data = _allowPublicExtensionData[_i];
+      JBAllowPublicExtensionData memory _data = _allowPublicExtensionData[_i];
 
       // Get the specs for the token ID.
       (uint256 _count, uint256 _duration, uint256 _lockedUntil, bool _useJbToken, ) = getSpecs(

--- a/contracts/JBveBanny.sol
+++ b/contracts/JBveBanny.sol
@@ -407,6 +407,7 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
     Only an account or a designated operator can unlock its tokens.
 
     @param _tokenId Banny Id.
+    @param _token The token to be reclaimed from the redemption.
     @param _minReturnedTokens The minimum amount of terminal tokens expected in return, as a fixed point number with the same amount of decimals as the terminal.
     @param _beneficiary The address to send the terminal tokens to.
     @param _memo A memo to pass along to the emitted event.
@@ -414,11 +415,12 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
   */
   function redeem(
     uint256 _tokenId,
+    address _token,
     uint256 _minReturnedTokens,
     address payable _beneficiary,
     string memory _memo,
     bytes memory _metadata,
-    IJBPayoutRedemptionPaymentTerminal _terminal
+    IJBRedemptionTerminal _terminal
   ) external nonReentrant {
     // Get the specs for the token ID.
     (uint256 _count, , uint256 _lockedUntil, , ) = getSpecs(_tokenId);
@@ -437,6 +439,7 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
       _owner,
       projectId,
       _count,
+      _token,
       _minReturnedTokens,
       _beneficiary,
       _memo,

--- a/contracts/JBveBanny.sol
+++ b/contracts/JBveBanny.sol
@@ -301,10 +301,15 @@ contract JBveBanny is ERC721Votes, ERC721Enumerable, Ownable, ReentrancyGuard, J
     if (!_isLockDurationAcceptable(_updatedDuration)) revert JBErrors.INVALID_LOCK_DURATION();
 
     // Get the specs for the token ID.
-    (uint256 _count, , uint256 _lockedUntil, bool _useJbToken) = getSpecs(_tokenId);
+    (uint256 _count, uint256 _duration, uint256 _lockedUntil, bool _useJbToken) = getSpecs(
+      _tokenId
+    );
+
+    // No time remaining if the lock has expired.
+    uint256 _timeRemaining = (block.timestamp >= _lockedUntil) ? 0 : _lockedUntil - block.timestamp;
 
     // Calculate the updated time when this lock will end (in seconds).
-    uint256 _updatedLockedUntil = block.timestamp + _updatedDuration;
+    uint256 _updatedLockedUntil = block.timestamp + _updatedDuration - _timeRemaining;
 
     // The new lock must be greater than the current lock.
     if (_lockedUntil > _updatedLockedUntil) revert INVALID_LOCK_EXTENSION();

--- a/contracts/libraries/JBStakingOperations.sol
+++ b/contracts/libraries/JBStakingOperations.sol
@@ -5,4 +5,5 @@ library JBStakingOperations {
   uint256 public constant LOCK = 19;
   uint256 public constant UNLOCK = 20;
   uint256 public constant EXTEND_LOCK = 21;
+  uint256 public constant SET_PUBLIC_EXTENSION_FLAG = 22;
 }

--- a/contracts/structs/JBAllowPublicExtensionData.sol
+++ b/contracts/structs/JBAllowPublicExtensionData.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
+/** 
+  @member tokenId The ID of the position.
+  @member allowPublicExtension A flag indicating whether or not the lock can be extended publicly by anyone.
+*/
 struct JBAllowPublicExtensionData {
-  // The ID of the position.
   uint256 tokenId;
-  // A flag indicating whether or not the lock can be extended publicly by anyone.
   bool allowPublicExtension;
 }

--- a/contracts/structs/JBAllowPublicExtensionData.sol
+++ b/contracts/structs/JBAllowPublicExtensionData.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+struct JBAllowPublicExtensionData {
+  uint256 tokenId;
+  uint256 allowPublicExtension;
+}

--- a/contracts/structs/JBAllowPublicExtensionData.sol
+++ b/contracts/structs/JBAllowPublicExtensionData.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.6;
 
 struct JBAllowPublicExtensionData {
+  // The ID of the position.
   uint256 tokenId;
-  uint256 allowPublicExtension;
+  // A flag indicating whether or not the lock can be extended publicly by anyone.
+  bool allowPublicExtension;
 }

--- a/contracts/structs/JBLockExtensionData.sol
+++ b/contracts/structs/JBLockExtensionData.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
+/** 
+  @member tokenId The ID of the position.
+  @member updatedDuration The updated duration of the lock.
+*/
 struct JBLockExtensionData {
-  // The ID of the position.
   uint256 tokenId;
-  // The updated duration of the lock.
   uint256 updatedDuration;
 }

--- a/contracts/structs/JBLockExtensionData.sol
+++ b/contracts/structs/JBLockExtensionData.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.6;
 
 struct JBLockExtensionData {
+  // The ID of the position.
   uint256 tokenId;
+  // The updated duration of the lock.
   uint256 updatedDuration;
 }

--- a/contracts/structs/JBLockExtensionData.sol
+++ b/contracts/structs/JBLockExtensionData.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+struct JBLockExtensionData {
+  uint256 tokenId;
+  uint256 updatedDuration;
+}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "solidity-coverage": "https://github.com/jbx-protocol/solidity-coverage.git#0fcd2f608c0e3e00bf66ab62c7610f5ea553fba8"
   },
   "dependencies": {
-    "@chainlink/contracts": "^0.1.6",
-    "@jbx-protocol/contracts-v2": "^0.0.21",
+    "@jbx-protocol/contracts-v2": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^2.1.4",
     "@openzeppelin/contracts": "4.5.0-rc.0",
     "@paulrberg/contracts": "^3.4.0",
@@ -30,7 +29,10 @@
     "esm": "^3.2.25",
     "glob": "^7.2.0",
     "hardhat-deploy-ethers": "^0.3.0-beta.10",
-    "prettier": "^2.4.0"
+    "prettier": "^2.4.0",
+    "prettier-plugin-solidity": "^1.0.0-beta.19",
+    "solhint": "^3.3.6",
+    "solhint-plugin-prettier": "^0.0.5"
   },
   "homepage": "https://github.com/jbx-protocol/juicehouse",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^0.1.6",
-    "@jbx-protocol/contracts-v2": "^0.0.20",
+    "@jbx-protocol/contracts-v2": "^0.0.21",
     "@nomiclabs/hardhat-etherscan": "^2.1.4",
     "@openzeppelin/contracts": "4.5.0-rc.0",
     "@paulrberg/contracts": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,10 +573,10 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@jbx-protocol/contracts-v2@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v2/-/contracts-v2-0.0.20.tgz#c718667b40c3180745e041ff6cdf97b8a917e4f4"
-  integrity sha512-OH6s02U8pnOdLqlJP1WIHh6oWcoMfZ/FxCURtDY4DwPvzqeeXdm3/midYLxGYB/qfhUxffACi9zSdD5n+46VsQ==
+"@jbx-protocol/contracts-v2@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v2/-/contracts-v2-0.0.21.tgz#955632a6eb087067e4ec00027bbf29a7502e2667"
+  integrity sha512-bbbesJ2ApVyyugEGaXtlJcl2WdyU10xExEArBkcvgbegXelZyJBSfOjpKhUXWUsnrXBOHmv/nRBoRn0FHOAGtw==
   dependencies:
     "@chainlink/contracts" "^0.1.6"
     "@nomiclabs/hardhat-etherscan" "^2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,10 +573,10 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@jbx-protocol/contracts-v2@^0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v2/-/contracts-v2-0.0.21.tgz#955632a6eb087067e4ec00027bbf29a7502e2667"
-  integrity sha512-bbbesJ2ApVyyugEGaXtlJcl2WdyU10xExEArBkcvgbegXelZyJBSfOjpKhUXWUsnrXBOHmv/nRBoRn0FHOAGtw==
+"@jbx-protocol/contracts-v2@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v2/-/contracts-v2-2.0.0.tgz#2ca8ea457d652403173ec4fc46c1ea2132872123"
+  integrity sha512-zjtz0xU5p7CJu3IY8C6eZj+qAvHHuF2ce50VVz7TNe506uBcgSEVoJ8P8HTOXl/qzEzQAXXO+51LZsKIwrTBrg==
   dependencies:
     "@chainlink/contracts" "^0.1.6"
     "@nomiclabs/hardhat-etherscan" "^2.1.4"


### PR DESCRIPTION
a few things here:

- lock extensions no longer add another increment of `duration`. Instead, lock extensions complete the lock to the specified duration. i.e. at 990 days left in a position, extending 1000 days will add 10 days to the position, not 1000.

- add a `allowPublicExtension` flag, that allows position owner to let anyone extend their locks for them. 

- add a `setAllowPublicExtension` function to allow position holders to toggle who can extend a lock.