### PR TITLE
Upgrade to JBX 2.0.0 and extend lock changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 cache
 artifacts
 deployments/localhost/**
+out/
 
 # Mac OSX
 .DS_Store

--- a/contracts/libraries/JBErrors.sol
+++ b/contracts/libraries/JBErrors.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
-
 library JBErrors {
-    // common errors
-    error INVALID_LOCK_DURATION();
-    error INSUFFICIENT_BALANCE();
+  // common errors
+  error INVALID_LOCK_DURATION();
+  error INSUFFICIENT_BALANCE();
 }

--- a/contracts/libraries/JBStakingOperations.sol
+++ b/contracts/libraries/JBStakingOperations.sol
@@ -5,4 +5,5 @@ library JBStakingOperations {
   uint256 public constant LOCK = 19;
   uint256 public constant UNLOCK = 20;
   uint256 public constant EXTEND_LOCK = 21;
+  uint256 public constant REDEEM = 22;
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^0.1.6",
-    "@jbx-protocol/contracts-v2": "^0.0.20",
+    "@jbx-protocol/contracts-v2": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^2.1.4",
     "@openzeppelin/contracts": "4.5.0-rc.0",
     "@paulrberg/contracts": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
 "@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
-  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
+  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
@@ -573,10 +573,10 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@jbx-protocol/contracts-v2@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v2/-/contracts-v2-0.0.20.tgz#c718667b40c3180745e041ff6cdf97b8a917e4f4"
-  integrity sha512-OH6s02U8pnOdLqlJP1WIHh6oWcoMfZ/FxCURtDY4DwPvzqeeXdm3/midYLxGYB/qfhUxffACi9zSdD5n+46VsQ==
+"@jbx-protocol/contracts-v2@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@jbx-protocol/contracts-v2/-/contracts-v2-2.0.0.tgz#2ca8ea457d652403173ec4fc46c1ea2132872123"
+  integrity sha512-zjtz0xU5p7CJu3IY8C6eZj+qAvHHuF2ce50VVz7TNe506uBcgSEVoJ8P8HTOXl/qzEzQAXXO+51LZsKIwrTBrg==
   dependencies:
     "@chainlink/contracts" "^0.1.6"
     "@nomiclabs/hardhat-etherscan" "^2.1.4"
@@ -8387,10 +8387,17 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.4, semver@^7.3.5:
+semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
- Upgraded npm package to newest version of JBX contracts
- Did some refactoring to get the tests working with the new contracts
- Burn old and mint new tokenId on extendLock
- Added some sections such as 'private helper functions' etc.
- Moved the specifications packing into a method to simplify the code and prevent accidental differences between them
- Changed `_holder` in `redeemTokensOf ` (see comments)
- Added modifier to `redeem(...)` (see comments)