### PR TITLE
deployer and generalize naming

### DIFF
--- a/contracts/JBVeNftDeployer.sol
+++ b/contracts/JBVeNftDeployer.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import './JBVeNft.sol';
+import './interfaces/IJBVeNftDeployer.sol';
+
+/**
+  @notice
+  Allows a project owner to deploy a veNFT contract.
+*/
+contract JBVeNftDeployer is IJBVeNftDeployer, JBOperatable {
+  /**
+    @notice
+    Mints ERC-721's that represent project ownership.
+  */
+  IJBProjects public immutable override projects;
+
+  //*********************************************************************//
+  // ---------------------------- constructor -------------------------- //
+  //*********************************************************************//
+
+  /**
+    @param _projects A contract which mints ERC-721's that represent project ownership and transfers.
+    @param _operatorStore A contract storing operator assignments.
+  */
+  constructor(IJBProjects _projects, IJBOperatorStore _operatorStore) JBOperatable(_operatorStore) {
+    projects = _projects;
+  }
+
+  //*********************************************************************//
+  // ---------------------- external transactions ---------------------- //
+  //*********************************************************************//
+
+  /** 
+    @notice 
+    Allows anyone to deploy a new project payer contract.
+
+    @param _projectId The ID of the project.
+    @param _name Nft name.
+    @param _symbol Nft symbol.
+    @param _uriResolver Token uri resolver instance.
+    @param _tokenStore The JBTokenStore where unclaimed tokens are accounted for.
+    @param _lockDurationOptions The lock options, in seconds, for lock durations.
+    @param _owner The address that will own the staking contract.
+
+    @return veNft The ve NFT contract that was deployed.
+  */
+  function deployVeNFT(
+    uint256 _projectId,
+    string memory _name,
+    string memory _symbol,
+    IJBVeTokenUriResolver _uriResolver,
+    IJBTokenStore _tokenStore,
+    IJBOperatorStore _operatorStore,
+    uint256[] memory _lockDurationOptions,
+    address _owner
+  )
+    external
+    override
+    requirePermission(projects.ownerOf(_projectId), _projectId, JBStakingOperations.DEPLOY_VE_NFT)
+    returns (IJBVeNft veNft)
+  {
+    // Deploy the ve nft contract.
+    veNft = new JBVeNft(
+      _projectId,
+      _name,
+      _symbol,
+      _uriResolver,
+      _tokenStore,
+      _operatorStore,
+      _lockDurationOptions,
+      _owner
+    );
+
+    emit DeployVeNft(
+      _projectId,
+      _name,
+      _symbol,
+      _uriResolver,
+      _tokenStore,
+      _operatorStore,
+      _lockDurationOptions,
+      _owner,
+      msg.sender
+    );
+  }
+}

--- a/contracts/JBVeTokenUriResolver.sol
+++ b/contracts/JBVeTokenUriResolver.sol
@@ -202,7 +202,7 @@ contract JBVeTokenUriResolver is IJBVeTokenUriResolver, Ownable {
      @notice Returns the token duration multiplier needed to index into the righteous veBanny mediallion background.
 
      @param _duration Time in seconds corresponding with one of five acceptable staking durations. 
-     The Staking durations below were gleaned from the JBveBanny.sol contract line 55-59.
+     The Staking durations below were gleaned from the JBVeNft.sol contract line 55-59.
      Returns the duration multiplier used to index into the proper veBanny mediallion on IPFS.
   */
   function _getTokenStakeMultiplier(uint256 _duration, uint256[] memory _lockDurationOptions)

--- a/contracts/interfaces/IJBVeNft.sol
+++ b/contracts/interfaces/IJBVeNft.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBTokenStore.sol';
+import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBOperatorStore.sol';
+import './IJBVeTokenUriResolver.sol';
+import './../structs/JBAllowPublicExtensionData.sol';
+import './../structs/JBLockExtensionData.sol';
+import './../structs/JBRedeemData.sol';
+import './../structs/JBUnlockData.sol';
+
+interface IJBVeNft {
+  function projectId() external view returns (uint256);
+
+  function tokenStore() external view returns (IJBTokenStore);
+
+  function count() external view returns (uint256);
+
+  function lockDurationOptions() external view returns (uint256[] memory);
+
+  function contractURI() external view returns (string memory);
+
+  function getSpecs(uint256 _tokenId)
+    external
+    view
+    returns (
+      uint256 amount,
+      uint256 duration,
+      uint256 lockedUntil,
+      bool useJbToken,
+      bool allowPublicExtension
+    );
+
+  function lock(
+    address _account,
+    uint256 _amount,
+    uint256 _duration,
+    address _beneficiary,
+    bool _useJbToken,
+    bool _allowPublicExtension
+  ) external returns (uint256 tokenId);
+
+  function unlock(JBUnlockData[] calldata _unlockData) external;
+
+  function extendLock(JBLockExtensionData[] calldata _lockExtensionData)
+    external
+    returns (uint256[] memory newTokenIds);
+
+  function setAllowPublicExtension(JBAllowPublicExtensionData[] calldata _allowPublicExtensionData)
+    external;
+
+  function redeem(JBRedeemData[] calldata _redeemData) external;
+
+  function setUriResolver(IJBVeTokenUriResolver _resolver) external;
+}

--- a/contracts/interfaces/IJBVeNftDeployer.sol
+++ b/contracts/interfaces/IJBVeNftDeployer.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBProjects.sol';
+import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBTokenStore.sol';
+import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBOperatorStore.sol';
+import './IJBVeTokenUriResolver.sol';
+import './IJBVeNft.sol';
+
+interface IJBVeNftDeployer {
+  event DeployVeNft(
+    uint256 indexed projectId,
+    string name,
+    string symbol,
+    IJBVeTokenUriResolver uriResolver,
+    IJBTokenStore tokenStore,
+    IJBOperatorStore operatorStore,
+    uint256[] lockDurationOptions,
+    address owner,
+    address caller
+  );
+
+  function projects() external view returns (IJBProjects);
+
+  function deployVeNFT(
+    uint256 _projectId,
+    string memory _name,
+    string memory _symbol,
+    IJBVeTokenUriResolver _uriResolver,
+    IJBTokenStore _tokenStore,
+    IJBOperatorStore _operatorStore,
+    uint256[] memory _lockDurationOptions,
+    address _owner
+  ) external returns (IJBVeNft veNft);
+}

--- a/contracts/libraries/JBStakingOperations.sol
+++ b/contracts/libraries/JBStakingOperations.sol
@@ -2,9 +2,10 @@
 pragma solidity 0.8.6;
 
 library JBStakingOperations {
-  uint256 public constant LOCK = 19;
-  uint256 public constant UNLOCK = 20;
-  uint256 public constant EXTEND_LOCK = 21;
-  uint256 public constant REDEEM = 22;
-  uint256 public constant SET_PUBLIC_EXTENSION_FLAG = 23;
+  uint256 public constant DEPLOY_VE_NFT = 19;
+  uint256 public constant LOCK = 20;
+  uint256 public constant UNLOCK = 21;
+  uint256 public constant EXTEND_LOCK = 22;
+  uint256 public constant REDEEM = 23;
+  uint256 public constant SET_PUBLIC_EXTENSION_FLAG = 24;
 }

--- a/contracts/test/TestJBveBanny.t.sol
+++ b/contracts/test/TestJBveBanny.t.sol
@@ -6,13 +6,13 @@ import '../veERC721.sol';
 import '../interfaces/IJBVeTokenUriResolver.sol';
 
 /**
-@title JBveBanny Forge Tests
+@title JBVeNft Forge Tests
 */
-contract JBveBannyTests is TestBaseWorkflow {
+contract JBVeNftTests is TestBaseWorkflow {
   //*********************************************************************//
   // --------------------- private stored properties ------------------- //
   //*********************************************************************//
-  JBveBanny private _jbveBanny;
+  JBVeNft private _jbveBanny;
   JBVeTokenUriResolver private _jbveTokenUriResolver;
   JBTokenStore private _jbTokenStore;
   JBController private _jbController;
@@ -49,8 +49,8 @@ contract JBveBannyTests is TestBaseWorkflow {
     _lockDurationOptions[1] = 4 weeks; // 4 weeks
     _lockDurationOptions[2] = 12 weeks; // 12 weeks
 
-    // JBveBanny
-    _jbveBanny = new JBveBanny(
+    // JBVeNft
+    _jbveBanny = new JBVeNft(
       _projectId,
       'Banny',
       'Banny',
@@ -365,14 +365,7 @@ contract JBveBannyTests is TestBaseWorkflow {
 
     vm.startPrank(_projectOwner);
 
-    uint256 _tokenId = _jbveBanny.lock(
-      _projectOwner,
-      5 ether,
-      1 weeks,
-      _projectOwner,
-      true,
-      false
-    );
+    uint256 _tokenId = _jbveBanny.lock(_projectOwner, 5 ether, 1 weeks, _projectOwner, true, false);
 
     // The unlock date gets rounded to the week, so it may not be exact
     uint256 unlockDate = ((block.timestamp + 1 weeks) / 1 weeks) * 1 weeks;
@@ -535,10 +528,7 @@ contract JBveBannyTests is TestBaseWorkflow {
     uint256 expectedVotingPower = (5 ether / MAXTIME) * singleWeekLockExactSeconds;
 
     // Check if the actual voting power is the same as the expected voting power
-    assertEq(
-      _jbveBanny.getVotes(_user) - _initialVotingPower,
-      expectedVotingPower
-    );
+    assertEq(_jbveBanny.getVotes(_user) - _initialVotingPower, expectedVotingPower);
   }
 
   /**
@@ -587,10 +577,7 @@ contract JBveBannyTests is TestBaseWorkflow {
     uint256 expectedVotingPower = (5 ether / MAXTIME) * singleWeekLockExactSeconds;
 
     // Check if the actual voting power is the same as the expected voting power
-    assertEq(
-      _jbveBanny.getVotes(_projectOwner) - _initialVotingPower,
-      expectedVotingPower
-    );
+    assertEq(_jbveBanny.getVotes(_projectOwner) - _initialVotingPower, expectedVotingPower);
   }
 
   /**
@@ -611,7 +598,6 @@ contract JBveBannyTests is TestBaseWorkflow {
     // Get the new voting power of the user
     uint256 _afterMintVotingPower = _jbveBanny.getVotes(_userA);
 
-
     // The unlock date gets rounded to the week, so it may not be exact
     uint256 unlockDate = ((block.timestamp + 1 weeks) / 1 weeks) * 1 weeks;
     // The exact amount of seconds until the 1 week lock expires
@@ -619,10 +605,7 @@ contract JBveBannyTests is TestBaseWorkflow {
     uint256 expectedVotingPower = (5 ether / MAXTIME) * singleWeekLockExactSeconds;
 
     // Check if the actual voting power is the same as the expected voting power
-    assertEq(
-      _afterMintVotingPower - _initialVotingPower,
-      expectedVotingPower
-    );
+    assertEq(_afterMintVotingPower - _initialVotingPower, expectedVotingPower);
 
     // Get the voting power of user B
     uint256 _userBVotingPowerBeforeTransfer = _jbveBanny.getVotes(_userB);
@@ -1002,7 +985,6 @@ contract JBveBannyTests is TestBaseWorkflow {
       // Lock the tokens and mint new NFT for user A
       vm.prank(_userA);
 
-      
       uint256 _tokenId = _jbveBanny.lock(_userA, _inputAmount, _inputDuration, _userA, true, false);
 
       // Get the new voting power of the user
@@ -1046,7 +1028,7 @@ contract JBveBannyTests is TestBaseWorkflow {
     if (_isDurationAcceptable) {
       vm.startPrank(_user);
       _jbToken.approve(_projectId, address(_jbveBanny), _inputAmount);
-      
+
       uint256 _tokenId = _jbveBanny.lock(
         _projectOwner,
         _inputAmount,
@@ -1069,7 +1051,7 @@ contract JBveBannyTests is TestBaseWorkflow {
       uint256 lockExactSeconds = (unlockDate - block.timestamp);
       uint256 expectedVotingPower = (_inputAmount / MAXTIME) * lockExactSeconds;
 
-    // Check if the actual voting power is the same as the expected voting power
+      // Check if the actual voting power is the same as the expected voting power
       assertEq(_jbveBanny.getVotes(_projectOwner) - _initialVotingPower, expectedVotingPower);
     }
   }

--- a/contracts/test/TestVeTokenUriResolver.sol
+++ b/contracts/test/TestVeTokenUriResolver.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.6;
 import './helpers/TestBaseWorkflow.t.sol';
 import '../interfaces/IJBVeTokenUriResolver.sol';
 
-contract JBveTokenUriResolverTests is TestBaseWorkflow {
+contract JBVeTokenUriResolverTests is TestBaseWorkflow {
   //*********************************************************************//
   // --------------------- private stored properties ------------------- //
   //*********************************************************************//
-  JBveBanny private _jbveBanny;
+  JBVeNft private _jbveBanny;
   JBVeTokenUriResolver private _jbveTokenUriResolver;
   JBTokenStore private _jbTokenStore;
   JBController private _jbController;
@@ -34,8 +34,8 @@ contract JBveTokenUriResolverTests is TestBaseWorkflow {
     _lockDurationOptions[1] = 2160000;
     _lockDurationOptions[2] = 8640000;
 
-    // JBveBanny
-    _jbveBanny = new JBveBanny(
+    // JBVeNft
+    _jbveBanny = new JBVeNft(
       _projectId,
       'Banny',
       'Banny',
@@ -63,7 +63,7 @@ contract JBveTokenUriResolverTests is TestBaseWorkflow {
     return _token;
   }
 
-  function testJBveTokenUriResolver() public view {
+  function testJBVeTokenUriResolver() public view {
     string memory uri = _jbveTokenUriResolver.tokenURI(
       0,
       1000000000000000000000, // 1000 Tokens

--- a/contracts/test/helpers/TestBaseWorkflow.t.sol
+++ b/contracts/test/helpers/TestBaseWorkflow.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
-import '../../JBveBanny.sol';
+import '../../JBVeNft.sol';
 import '../../JBVeTokenUriResolver.sol';
 import './AccessJBLib.sol';
 import 'forge-std/Test.sol';
@@ -145,7 +145,6 @@ abstract contract TestBaseWorkflow is Test {
   function jbToken() internal view returns (JBToken) {
     return _paymentToken;
   }
-
 
   //*********************************************************************//
   // --------------------------- test setup ---------------------------- //

--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -61,7 +61,7 @@ module.exports = async ({ getNamedAccounts, deployments, getChainId }) => {
     ]
   ];
 
-  const veBanny = await deploy('JBveBanny', {
+  const veBanny = await deploy('JBVeNft', {
     ...baseDeployArgs,
     args: veBannyArgs,
   });


### PR DESCRIPTION
Added:

- deployer contract. callable by project owners or operators to deploy a new staking contract. emits an event that's indexable.
- renamed veBanny to veNft to generalize. wyt?